### PR TITLE
feat: Add event map and thumbnail files source

### DIFF
--- a/crates/admin/src/populate.rs
+++ b/crates/admin/src/populate.rs
@@ -66,6 +66,8 @@ struct Row {
     original_map_uid: Option<String>,
     original_mx_id: Option<i64>,
     transitive_save: Option<bool>,
+    source: Option<String>,
+    thumbnail_source: Option<String>,
 }
 
 fn get_id_impl(uid: Option<&str>, mx_id: Option<i64>) -> Option<Id<'_>> {
@@ -480,6 +482,8 @@ async fn populate_from_csv<C: ConnectionTrait>(
             silver_time: Set(silver_time),
             gold_time: Set(gold_time),
             author_time: Set(author_time),
+            source: Set(row.source),
+            thumbnail_source: Set(row.thumbnail_source),
         };
 
         maps_to_insert.push(new_map);

--- a/crates/entity/src/entities/event_edition_maps.rs
+++ b/crates/entity/src/entities/event_edition_maps.rs
@@ -36,6 +36,14 @@ pub struct Model {
     pub gold_time: Option<i32>,
     /// The time of the author medal.
     pub author_time: Option<i32>,
+    /// The source of the map.
+    ///
+    /// This is an optional URL to the map file. By default, the map file is retrieved from SMX.
+    pub source: Option<String>,
+    /// The source of the thumbnail of the map.
+    ///
+    /// This is an optional URL to the map thumbnail file. By default, the file is retrieved from SMX.
+    pub thumbnail_source: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/game_api/src/http/event.rs
+++ b/crates/game_api/src/http/event.rs
@@ -66,6 +66,8 @@ struct MapWithCategory {
     category_id: Option<u32>,
     mx_id: Option<i64>,
     original_map_id: Option<u32>,
+    source: Option<String>,
+    thumbnail_source: Option<String>,
 }
 
 async fn get_maps_by_edition_id<C: ConnectionTrait>(
@@ -89,6 +91,8 @@ async fn get_maps_by_edition_id<C: ConnectionTrait>(
             event_edition_maps::Column::CategoryId,
             event_edition_maps::Column::MxId,
             event_edition_maps::Column::OriginalMapId,
+            event_edition_maps::Column::Source,
+            event_edition_maps::Column::ThumbnailSource,
         ])
         .into_model()
         .all(conn)
@@ -158,6 +162,8 @@ struct Map {
     personal_best: NullableInteger,
     next_opponent: NextOpponent,
     original_map: OriginalMap,
+    source: NullableText,
+    thumbnail_source: NullableText,
 }
 
 #[derive(Serialize, Default)]
@@ -454,13 +460,16 @@ async fn edition(
 
         let mut maps = Vec::with_capacity(cat_maps.size_hint().0);
 
-        for MapWithCategory {
-            map,
-            mx_id,
-            original_map_id,
-            ..
-        } in cat_maps
-        {
+        for cat_map in cat_maps {
+            let MapWithCategory {
+                map,
+                mx_id,
+                original_map_id,
+                source,
+                thumbnail_source,
+                ..
+            } = cat_map;
+
             let main_author = players::Entity::find_by_id(map.player_id)
                 .select_only()
                 .columns([
@@ -655,6 +664,8 @@ async fn edition(
                 original_map,
                 personal_best,
                 next_opponent: next_opponent.unwrap_or_default(),
+                source: source.into(),
+                thumbnail_source: thumbnail_source.into(),
             });
         }
 

--- a/crates/game_api/tests/player_finished_event.rs
+++ b/crates/game_api/tests/player_finished_event.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use actix_http::StatusCode;
 use actix_web::test;
 use entity::{

--- a/crates/migration/src/lib.rs
+++ b/crates/migration/src/lib.rs
@@ -2,6 +2,8 @@ mod m20250806_183646_initial;
 mod m20250806_191853_first;
 mod m20250806_191954_create_views;
 mod m20250806_202048_populate;
+mod m20250918_132016_add_event_edition_maps_source;
+mod m20250918_135135_add_event_edition_maps_thumbnail_source;
 
 use sea_orm_migration::prelude::*;
 
@@ -17,6 +19,8 @@ impl MigratorTrait for Migrator {
             Box::new(m20250806_191853_first::Migration),
             Box::new(m20250806_191954_create_views::Migration),
             Box::new(m20250806_202048_populate::Migration),
+            Box::new(m20250918_132016_add_event_edition_maps_source::Migration),
+            Box::new(m20250918_135135_add_event_edition_maps_thumbnail_source::Migration),
         ]
     }
 }

--- a/crates/migration/src/m20250918_132016_add_event_edition_maps_source.rs
+++ b/crates/migration/src/m20250918_132016_add_event_edition_maps_source.rs
@@ -1,0 +1,40 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(EventEditionMaps::Table)
+                    .add_column(
+                        ColumnDef::new(EventEditionMaps::Source)
+                            .text()
+                            .null()
+                            .take(),
+                    )
+                    .take(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(EventEditionMaps::Table)
+                    .drop_column(EventEditionMaps::Source)
+                    .take(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum EventEditionMaps {
+    Table,
+    Source,
+}

--- a/crates/migration/src/m20250918_135135_add_event_edition_maps_thumbnail_source.rs
+++ b/crates/migration/src/m20250918_135135_add_event_edition_maps_thumbnail_source.rs
@@ -1,0 +1,40 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(EventEditionMaps::Table)
+                    .add_column(
+                        ColumnDef::new(EventEditionMaps::ThumbnailSource)
+                            .text()
+                            .null()
+                            .take(),
+                    )
+                    .take(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(EventEditionMaps::Table)
+                    .drop_column(EventEditionMaps::ThumbnailSource)
+                    .take(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum EventEditionMaps {
+    Table,
+    ThumbnailSource,
+}

--- a/crates/records_lib/src/event.rs
+++ b/crates/records_lib/src/event.rs
@@ -309,6 +309,7 @@ pub async fn get_editions_which_contain<C: ConnectionTrait + StreamTrait>(
         .filter(
             event_edition::Column::SaveNonEventRecord
                 .ne(0)
+                .and(event_edition::Column::IsTransparent.eq(0))
                 .and(event_edition_maps::Column::MapId.eq(map_id)),
         )
         .select_only()


### PR DESCRIPTION
* For `/event/<handle>/<edition>` API service, added newer `"source"` and `"thumbnail_source"` field. These fields are empty strings most of the time, except for maps that are hidden from MX. The client Titlepack should request MX to download the map file and the thumbnail file if the corresponding values are empty, or download them from the provided URL instead.
* Added the corresponding columns in the database with migrations.

Closes: #78.