### PR TITLE
feat: Better rank compute error management

### DIFF
--- a/crates/game_api/Cargo.toml
+++ b/crates/game_api/Cargo.toml
@@ -22,7 +22,7 @@ actix-cors = { workspace = true }
 actix-http = "3.11.0"
 async-graphql-actix-web = { workspace = true }
 tracing-actix-web = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["multipart"] }
 rand = { workspace = true }
 futures = { workspace = true }
 sha256 = { workspace = true }
@@ -41,10 +41,10 @@ sea-orm = { workspace = true }
 migration = { path = "../migration" }
 entity = { path = "../entity" }
 graphql-api = { path = "../graphql-api" }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 records-lib = { path = "../records_lib" }
-serde_json = { workspace = true }
 
 [features]
 default = ["request_filter"]

--- a/crates/game_api/src/env.rs
+++ b/crates/game_api/src/env.rs
@@ -41,6 +41,7 @@ const DEFAULT_MP_CLIENT_SECRET: &str = "";
 const DEFAULT_WH_REPORT_URL: &str = "";
 const DEFAULT_WH_AC_URL: &str = "";
 const DEFAULT_WH_INVALID_REQ_URL: &str = "";
+const DEFAULT_WH_RANK_COMPUTE_ERROR: &str = "";
 const DEFAULT_GQL_ENDPOINT: &str = "/graphql";
 
 mkenv::make_env! {pub ApiEnv includes [
@@ -126,6 +127,14 @@ mkenv::make_env! {pub ApiEnv includes [
         var: "GQL_ENDPOINT",
         desc: "The route to the GraphQL endpoint (e.g. /graphql)",
         default: DEFAULT_GQL_ENDPOINT,
+    },
+
+    wh_rank_compute_err: {
+        id: WebhookRankComputeError(String),
+        kind: normal,
+        var: "WEBHOOK_RANK_COMPUTE_ERROR",
+        desc: "The URL to the Discord webhook used to send rank compute errors",
+        default: DEFAULT_WH_RANK_COMPUTE_ERROR,
     },
 }
 

--- a/crates/game_api/src/error.rs
+++ b/crates/game_api/src/error.rs
@@ -127,6 +127,9 @@ where
             E::Lib(e) if matches!(e.as_ref(), LE::MaskedInternal) => {
                 (111, S::INTERNAL_SERVER_ERROR)
             }
+            E::Lib(e) if matches!(e.as_ref(), LE::RankCompute(_)) => {
+                (112, S::INTERNAL_SERVER_ERROR)
+            }
 
             E::Unauthorized => (201, S::UNAUTHORIZED),
             E::Forbidden => (202, S::FORBIDDEN),

--- a/crates/game_api/src/graphql.rs
+++ b/crates/game_api/src/graphql.rs
@@ -7,6 +7,7 @@ use async_graphql_actix_web::GraphQLRequest;
 use graphql_api::error::{ApiGqlError, ApiGqlErrorKind};
 use graphql_api::schema::{Schema, create_schema};
 use records_lib::Database;
+use records_lib::error::RecordsError;
 use reqwest::Client;
 use tracing_actix_web::RequestId;
 
@@ -46,9 +47,9 @@ async fn index_graphql(
 
         // Don't expose internal server errors
         if let Some(err) = api_error
-            && let ApiGqlErrorKind::Lib(err) = err.kind()
+            && let ApiGqlErrorKind::Lib(records_err) = err.kind()
         {
-            let err = ApiErrorKind::Lib(err);
+            let err = ApiErrorKind::Lib(records_err);
             let (err_type, status_code) = err.get_err_type_and_status_code();
 
             let mapped_err_type = if (100..200).contains(&err_type) || status_code.is_server_error()
@@ -60,6 +61,15 @@ async fn index_graphql(
                     request_id,
                     err,
                 );
+
+                if let RecordsError::RankCompute(err) = records_err {
+                    configure::send_compute_err_msg_detached(
+                        client.0.clone(),
+                        request_id,
+                        err.clone(),
+                    );
+                }
+
                 105 // Unknown type
             } else {
                 err_type

--- a/crates/game_api/src/main.rs
+++ b/crates/game_api/src/main.rs
@@ -88,6 +88,7 @@ async fn main() -> anyhow::Result<()> {
 
         App::new()
             .wrap(cors)
+            .wrap(middleware::from_fn(configure::mask_rank_compute_error))
             .wrap(middleware::from_fn(configure::mask_internal_errors))
             .wrap(middleware::from_fn(configure::fit_request_id))
             .wrap(TracingLogger::<configure::RootSpanBuilder>::new())

--- a/crates/graphql-api/src/error.rs
+++ b/crates/graphql-api/src/error.rs
@@ -173,12 +173,9 @@ impl fmt::Display for ApiGqlError {
 }
 
 impl From<ApiGqlError> for async_graphql::Error {
+    #[inline(always)]
     fn from(value: ApiGqlError) -> Self {
-        Self {
-            message: value.to_string(),
-            extensions: None,
-            source: Some(value.inner),
-        }
+        async_graphql::Error::new_with_source(value)
     }
 }
 

--- a/crates/graphql-api/src/objects/map.rs
+++ b/crates/graphql-api/src/objects/map.rs
@@ -367,7 +367,16 @@ impl Map {
                 },
             )
             .await
-            .map_err(ApiGqlError::from_gql_error)
+            .map_err(|e| {
+                match e
+                    .source
+                    .as_ref()
+                    .and_then(|source| source.downcast_ref::<ApiGqlError>())
+                {
+                    Some(err) => err.clone(),
+                    None => ApiGqlError::from_gql_error(e),
+                }
+            })
         }))
         .await
     }

--- a/crates/graphql-api/src/objects/player.rs
+++ b/crates/graphql-api/src/objects/player.rs
@@ -138,7 +138,16 @@ impl Player {
                 },
             )
             .await
-            .map_err(ApiGqlError::from_gql_error)
+            .map_err(|e| {
+                match e
+                    .source
+                    .as_ref()
+                    .and_then(|source| source.downcast_ref::<ApiGqlError>())
+                {
+                    Some(err) => err.clone(),
+                    None => ApiGqlError::from_gql_error(e),
+                }
+            })
         }))
         .await
     }

--- a/crates/graphql-api/src/objects/root.rs
+++ b/crates/graphql-api/src/objects/root.rs
@@ -371,7 +371,16 @@ impl QueryRoot {
                 },
             )
             .await
-            .map_err(ApiGqlError::from_gql_error)
+            .map_err(|e| {
+                match e
+                    .source
+                    .as_ref()
+                    .and_then(|source| source.downcast_ref::<ApiGqlError>())
+                {
+                    Some(err) => err.clone(),
+                    None => ApiGqlError::from_gql_error(e),
+                }
+            })
         })
         .await
     }

--- a/crates/records_lib/Cargo.toml
+++ b/crates/records_lib/Cargo.toml
@@ -20,7 +20,6 @@ nom = { workspace = true }
 rand = { workspace = true }
 sea-orm = { workspace = true }
 entity = { path = "../entity" }
-prettytable = { workspace = true }
 
 [features]
 default = []

--- a/crates/records_lib/src/error.rs
+++ b/crates/records_lib/src/error.rs
@@ -3,17 +3,9 @@
 use deadpool_redis::PoolError;
 use sea_orm::TransactionError;
 
+use crate::ranks::RankComputeError;
+
 /// Represents any type of error that could happen when using this crate.
-///
-/// To be handled by the ShootMania Obstacle gamemode, each kind of error has an associated code.
-///
-/// * `100..=199` errors represent internal server errors.
-/// * `200..=299` errors represent authentication errors.
-/// * `300..=399` errors represent logical errors (for example, an invalid player login).
-///
-/// This semantic is only used by the `game_api` crate when returning errors. It also has its own
-/// error types that are not present here, with their associated code. These codes should not be
-/// in conflict.
 #[derive(thiserror::Error, Debug)]
 #[rustfmt::skip]
 pub enum RecordsError {
@@ -42,6 +34,9 @@ pub enum RecordsError {
     /// An error from the database.
     #[error(transparent)]
     DbError(#[from] sea_orm::DbErr),
+    /// An error when computing the rank of a player on a map.
+    #[error(transparent)]
+    RankCompute(#[from] RankComputeError),
 
     // --------
     // --- Logical errors


### PR DESCRIPTION
* Instead of printing leaderboard differences between Redis and the SQL database to stdout, return an error early, and notify the error in a middleware handled by the game-api crate.
* This implies a new error type in the `records_lib::ranks` module, returned by the `get_rank` function.
* A Discord Webhook is used to notify the error, by sending the general info of the error in an embed, and the leaderboard of the Redis and SQL database versions in separate files, to help using a diff-tool between them.
* Also fix internal error not being correctly catched in the `/graphql` service.

Refs: #94.